### PR TITLE
BST-3595 - Ruby 2.7.0 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
-repos/*
 .DS_Store
-vendor/bundler/*
-vendor/bundle/*
+.anvil/
 .env
 .ruby-version
 buildpacks/*
-.anvil/
+repos/*
 tmp/*.log
+vendor/bundle/*
+vendor/bundler/*

--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,10 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "2.6.3"
+ruby "2.7.0"
 
 group :development, :test do
-  gem "boxt_ruby_style_guide", "3.0.0"
+  gem "boxt_ruby_style_guide", "3.1.0"
   gem "ci-queue"
   gem "excon"
   gem "git", github: "hone/ruby-git", branch: "master"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,4 +136,4 @@ RUBY VERSION
    ruby 2.7.0p0
 
 BUNDLED WITH
-   2.1.3
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    boxt_ruby_style_guide (3.0.0)
+    boxt_ruby_style_guide (3.1.0)
       reek (~> 5.3, >= 5.3.0)
       rubocop (~> 0.67.2)
     ci-queue (0.16.0)
@@ -52,7 +52,7 @@ GEM
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    jaro_winkler (1.5.3)
+    jaro_winkler (1.5.4)
     json (2.0.4)
     kwalify (0.7.2)
     minitest (5.11.3)
@@ -64,7 +64,7 @@ GEM
     parallel (1.17.0)
     parallel_tests (2.29.0)
       parallel
-    parser (2.6.3.0)
+    parser (2.6.5.0)
       ast (~> 2.4.0)
     platform-api (2.2.0)
       heroics (~> 0.0.25)
@@ -73,7 +73,7 @@ GEM
     rainbow (3.0.0)
     rake (12.3.2)
     redis (4.1.2)
-    reek (5.4.0)
+    reek (5.5.0)
       codeclimate-engine-rb (~> 0.4.0)
       kwalify (~> 0.7.0)
       parser (>= 2.5.0.0, < 2.7, != 2.5.1.1)
@@ -117,7 +117,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  boxt_ruby_style_guide (= 3.0.0)
+  boxt_ruby_style_guide (= 3.1.0)
   ci-queue
   excon
   git!
@@ -133,7 +133,7 @@ DEPENDENCIES
   toml-rb
 
 RUBY VERSION
-   ruby 2.6.3
+   ruby 2.7.0p0
 
 BUNDLED WITH
-   2.0.2
+   2.1.3

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'language_pack/fetcher'
+require "language_pack/fetcher"
 
 # This class is responsible for installing and maintaining a
 # reference to bundler. It contains access to bundler internals
@@ -37,7 +37,7 @@ class LanguagePack::Helpers::BundlerWrapper
 
   BLESSED_BUNDLER_VERSIONS = {
     "1" => "1.15.2",
-    "2" => "2.1.3"
+    "2" => "2.1.4"
   }.freeze
 
   private_constant :BLESSED_BUNDLER_VERSIONS
@@ -62,7 +62,7 @@ class LanguagePack::Helpers::BundlerWrapper
       msg << "\n"
       msg << "```\n"
       msg << "BUNDLED WITH\n"
-      msg << "   #{version_hash["1"]}\n"
+      msg << "   #{version_hash['1']}\n"
       msg << "```\n"
       super msg
     end
@@ -79,12 +79,12 @@ class LanguagePack::Helpers::BundlerWrapper
 
     @bundler_path         = options[:bundler_path] || @bundler_tmp.join(dir_name)
     @bundler_tar          = options[:bundler_tar]  || "bundler/#{dir_name}.tgz"
-    @orig_bundle_gemfile  = ENV['BUNDLE_GEMFILE']
+    @orig_bundle_gemfile  = ENV["BUNDLE_GEMFILE"]
     @path                 = Pathname.new("#{@bundler_path}/gems/#{dir_name}/lib")
   end
 
   def install
-    ENV['BUNDLE_GEMFILE'] = @gemfile_path.to_s
+    ENV["BUNDLE_GEMFILE"] = @gemfile_path.to_s
 
     fetch_bundler
     $LOAD_PATH << @path
@@ -93,7 +93,7 @@ class LanguagePack::Helpers::BundlerWrapper
   end
 
   def clean
-    ENV['BUNDLE_GEMFILE'] = @orig_bundle_gemfile
+    ENV["BUNDLE_GEMFILE"] = @orig_bundle_gemfile
     @bundler_tmp.rmtree if @bundler_tmp.directory?
   end
 
@@ -118,16 +118,14 @@ class LanguagePack::Helpers::BundlerWrapper
   end
 
   def specs
-    @specs ||= lockfile_parser.specs.each_with_object({}) {|spec, hash| hash[spec.name] = spec }
+    @specs ||= lockfile_parser.specs.each_with_object({}) { |spec, hash| hash[spec.name] = spec }
   end
 
   def platforms
     @platforms ||= lockfile_parser.platforms
   end
 
-  def version
-    @version
-  end
+  attr_reader :version
 
   def dir_name
     "bundler-#{version}"
@@ -138,23 +136,23 @@ class LanguagePack::Helpers::BundlerWrapper
   end
 
   def ruby_version
-    instrument 'detect_ruby_version' do
-      env = { "PATH"     => "#{bundler_path}/bin:#{ENV['PATH']}",
-              "RUBYLIB"  => File.join(bundler_path, "gems", dir_name, "lib"),
-              "GEM_PATH" => "#{bundler_path}:#{ENV["GEM_PATH"]}",
-              "BUNDLE_DISABLE_VERSION_CHECK" => "true"
-            }
+    instrument "detect_ruby_version" do
+      env = { "PATH" => "#{bundler_path}/bin:#{ENV['PATH']}",
+              "RUBYLIB" => File.join(bundler_path, "gems", dir_name, "lib"),
+              "GEM_PATH" => "#{bundler_path}:#{ENV['GEM_PATH']}",
+              "BUNDLE_DISABLE_VERSION_CHECK" => "true" }
       command = "bundle platform --ruby"
 
       # Silently check for ruby version
-      output  = run_stdout(command, user_env: true, env: env).strip.lines.last
+      output = run_stdout(command, user_env: true, env: env).strip.lines.last
 
       # If there's a gem in the Gemfile (i.e. syntax error) emit error
-      raise GemfileParseError.new(run("bundle check", user_env: true, env: env)) unless $?.success?
+      raise GemfileParseError, run("bundle check", user_env: true, env: env) unless $CHILD_STATUS.success?
+
       if output.match(/No ruby version specified/)
         ""
       else
-        output.chomp.sub('(', '').sub(')', '').sub(/(p-?\d+)/, ' \1').split.join('-')
+        output.chomp.sub("(", "").sub(")", "").sub(/(p-?\d+)/, ' \1').split.join("-")
       end
     end
   end
@@ -164,19 +162,21 @@ class LanguagePack::Helpers::BundlerWrapper
   end
 
   private
+
   def fetch_bundler
-    instrument 'fetch_bundler' do
-      return true if Dir.exists?(bundler_path)
+    instrument "fetch_bundler" do
+      return true if Dir.exist?(bundler_path)
+
       FileUtils.mkdir_p(bundler_path)
       Dir.chdir(bundler_path) do
         @fetcher.fetch_untar(@bundler_tar)
       end
-      Dir["bin/*"].each {|path| `chmod 755 #{path}` }
+      Dir["bin/*"].each { |path| `chmod 755 #{path}` }
     end
   end
 
   def parse_gemfile_lock
-    instrument 'parse_bundle' do
+    instrument "parse_bundle" do
       gemfile_contents = File.read(@gemfile_lock_path)
       Bundler::LockfileParser.new(gemfile_contents)
     end

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -35,9 +35,11 @@ require 'language_pack/fetcher'
 class LanguagePack::Helpers::BundlerWrapper
   include LanguagePack::ShellHelpers
 
-  BLESSED_BUNDLER_VERSIONS = {}
-  BLESSED_BUNDLER_VERSIONS["1"] = "1.15.2"
-  BLESSED_BUNDLER_VERSIONS["2"] = "2.0.2"
+  BLESSED_BUNDLER_VERSIONS = {
+    "1" => "1.15.2",
+    "2" => "2.1.3"
+  }.freeze
+
   private_constant :BLESSED_BUNDLER_VERSIONS
 
   class GemfileParseError < BuildpackError


### PR DESCRIPTION
Upgrading Ruby to 2.7.0 and Bundler to the latest 2.1.3 version.