### PR TITLE
Reset version numbers after merging upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Master (unreleased)
 
+* Default node version now 10.20.0 (https://github.com/boxt/heroku-buildpack-ruby/pull/5)
 * Default node version now 12.16.2, yarn is 1.22.4 (https://github.com/heroku/heroku-buildpack-ruby/pull/986)
 * Gracefully handle unrecognised stacks ([#982](https://github.com/heroku/heroku-buildpack-ruby/pull/982))
 

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -37,7 +37,7 @@ class LanguagePack::Helpers::BundlerWrapper
 
   BLESSED_BUNDLER_VERSIONS = {}.freeze
   BLESSED_BUNDLER_VERSIONS["1"] = "1.17.3"
-  BLESSED_BUNDLER_VERSIONS["2"] = "2.0.2"
+  BLESSED_BUNDLER_VERSIONS["2"] = "2.1.4"
   BUNDLED_WITH_REGEX = /^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.\d+\.\d+/m.freeze
 
   class GemfileParseError < BuildpackError

--- a/lib/language_pack/helpers/nodebin.rb
+++ b/lib/language_pack/helpers/nodebin.rb
@@ -3,19 +3,20 @@
 require "json"
 
 class LanguagePack::Helpers::Nodebin
+  NODE_VERSION = "10.20.0" # We currently can't use "12.16.2" of Node because of issues installing canvas-prebuilt
+  YARN_VERSION = "1.22.4"
+
   def self.hardcoded_node_lts
-    version = "12.16.2"
     {
-      "number" => version,
-      "url" => "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v#{version}-linux-x64.tar.gz"
+      "number" => NODE_VERSION,
+      "url" => "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v#{NODE_VERSION}-linux-x64.tar.gz"
     }
   end
 
   def self.hardcoded_yarn
-    version = "1.22.4"
     {
-      "number" => version,
-      "url" => "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v#{version}.tar.gz"
+      "number" => YARN_VERSION,
+      "url" => "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v#{YARN_VERSION}.tar.gz"
     }
   end
 


### PR DESCRIPTION
Also using `10.20.0` of Node for now, as `10.20.1` is not available via `brew`. If this gets released soon will bump the version.